### PR TITLE
Scroll political party

### DIFF
--- a/app/components/DeputiesTable/PartyButton.js
+++ b/app/components/DeputiesTable/PartyButton.js
@@ -32,6 +32,7 @@ export default function PartyButton({ party, setParty }) {
         closeOnSelect={false}
         selectedKeys={party}
         defaultSelectedKeys="all"
+        className="overflow-y-auto max-h-96"
         selectionMode="single"
         onSelectionChange={(e) => {
           if (e.currentKey === "all") {

--- a/app/components/DeputiesTable/StatesButton.js
+++ b/app/components/DeputiesTable/StatesButton.js
@@ -31,7 +31,7 @@ export default function StatesButton({ state, setState }) {
         disallowEmptySelection={true}
         closeOnSelect={false}
         selectedKeys={state}
-        className="overflow-y-auto max-h-96 "
+        className="overflow-y-auto max-h-96"
         defaultSelectedKeys="all"
         selectionMode="single"
         onSelectionChange={(e) => {


### PR DESCRIPTION
### Description
* [x]  Corrigir erro de altura máxima do card dos partidos políticos em telas menores

#### Nota
* Em telas menores, o card dos partidos políticos estava ocupando a tela até o final e não tinha a opção de scroll.
<img width="367" alt="Captura de Tela 2023-10-01 às 00 02 50" src="https://github.com/brasiliapp/web/assets/10791688/35c19b56-6817-4a3e-b96a-dcebeb301d22">
